### PR TITLE
Enables parameter overrides to be used in interpolating class names.

### DIFF
--- a/reclass/core.py
+++ b/reclass/core.py
@@ -125,6 +125,8 @@ class Core(object):
                     klass = str(self._parser.parse(klass, self._settings).render(merge_base.parameters.as_dict(), {}))
                 except ResolveError as e:
                     try:
+                        # interpolate parameters before using them in the klass name. Used for overrides
+                        context.parameters.initialise_interpolation()
                         klass = str(self._parser.parse(klass, self._settings).render(context.parameters.as_dict(), {}))
                     except ResolveError as e:
                         raise ClassNameResolveError(klass, nodename, entity.uri)

--- a/reclass/datatypes/parameters.py
+++ b/reclass/datatypes/parameters.py
@@ -184,7 +184,12 @@ class Parameters(object):
             else:
                 value = self._merge_recurse(cur.get(key), value)
             cur[key] = value
-        cur.uri = new.uri
+        
+        try:
+            cur.uri = new.uri
+        except AttributeError:
+            cur['uri'] = new.uri
+
         return cur
 
     def _merge_recurse(self, cur, new):

--- a/reclass/tests/data/05/classes/components/cluster-autoscaler/v0.yml
+++ b/reclass/tests/data/05/classes/components/cluster-autoscaler/v0.yml
@@ -1,0 +1,3 @@
+parameters:
+  loaded_from:
+    cluster_autoscaler: v0

--- a/reclass/tests/data/05/classes/components/cluster-autoscaler/v1.yml
+++ b/reclass/tests/data/05/classes/components/cluster-autoscaler/v1.yml
@@ -1,0 +1,3 @@
+parameters:
+  loaded_from:
+    cluster_autoscaler: v1

--- a/reclass/tests/data/05/classes/components/common.yml
+++ b/reclass/tests/data/05/classes/components/common.yml
@@ -1,0 +1,3 @@
+classes:
+  - components.core-dns.${default_versions:core_dns}
+  - components.cluster-autoscaler.${default_versions:cluster_autoscaler}

--- a/reclass/tests/data/05/classes/components/core-dns/v0.yml
+++ b/reclass/tests/data/05/classes/components/core-dns/v0.yml
@@ -1,0 +1,3 @@
+parameters:
+  loaded_from:
+    core_dns: v0

--- a/reclass/tests/data/05/classes/components/core-dns/v1.yml
+++ b/reclass/tests/data/05/classes/components/core-dns/v1.yml
@@ -1,0 +1,3 @@
+parameters:
+  loaded_from:
+    core_dns: v1

--- a/reclass/tests/data/05/classes/versions/default_versions.yml
+++ b/reclass/tests/data/05/classes/versions/default_versions.yml
@@ -1,0 +1,4 @@
+parameters:
+  default_versions:
+    core_dns: v0
+    cluster_autoscaler: v0

--- a/reclass/tests/data/05/classes/versions/dev.yml
+++ b/reclass/tests/data/05/classes/versions/dev.yml
@@ -1,0 +1,6 @@
+classes:
+  - versions.default_versions
+parameters:
+  default_versions:
+    core_dns: v1
+    cluster_autoscaler: v1

--- a/reclass/tests/data/05/classes/versions/prd.yml
+++ b/reclass/tests/data/05/classes/versions/prd.yml
@@ -1,0 +1,4 @@
+classes:
+  - versions.default_versions
+parameters:
+

--- a/reclass/tests/data/05/classes/versions/stg.yml
+++ b/reclass/tests/data/05/classes/versions/stg.yml
@@ -1,0 +1,5 @@
+classes:
+  - versions.default_versions
+parameters:
+  default_versions:
+    core_dns: v1

--- a/reclass/tests/data/05/nodes/dev.yml
+++ b/reclass/tests/data/05/nodes/dev.yml
@@ -1,0 +1,9 @@
+classes:
+  - versions.dev
+  - components.common
+
+parameters:
+  kapitan:
+    vars:
+      target: dev
+

--- a/reclass/tests/data/05/nodes/prd.yml
+++ b/reclass/tests/data/05/nodes/prd.yml
@@ -1,0 +1,9 @@
+classes:
+  - versions.prd
+  - components.common
+
+parameters:
+  kapitan:
+    vars:
+      target: prd
+

--- a/reclass/tests/data/05/nodes/stg.yml
+++ b/reclass/tests/data/05/nodes/stg.yml
@@ -1,0 +1,9 @@
+classes:
+  - versions.stg
+  - components.common
+
+parameters:
+  kapitan:
+    vars:
+      target: stg
+

--- a/reclass/tests/test_core.py
+++ b/reclass/tests/test_core.py
@@ -97,6 +97,22 @@ class TestCore(unittest.TestCase):
         node = reclass.nodeinfo('node1')
         params = { 'test1': 1, 'test3': 3, '_reclass_': {'environment': u'base', 'name': {'full': 'node1', 'short': 'node1'}}}
         self.assertEqual(node['parameters'], params)
+    
+    def test_merging_of_parameters_before_class_interpolation_enabling_overrides(self):
+        reclass = self._core('05')
+
+        dev = reclass.nodeinfo('dev')
+        stg = reclass.nodeinfo('stg')
+        prd = reclass.nodeinfo('prd')
+
+        self.assertEqual(dev['parameters']['loaded_from']['core_dns'], 'v1')
+        self.assertEqual(dev['parameters']['loaded_from']['cluster_autoscaler'], 'v1')
+
+        self.assertEqual(stg['parameters']['loaded_from']['core_dns'], 'v1')
+        self.assertEqual(stg['parameters']['loaded_from']['cluster_autoscaler'], 'v0')
+
+        self.assertEqual(prd['parameters']['loaded_from']['core_dns'], 'v0')
+        self.assertEqual(prd['parameters']['loaded_from']['cluster_autoscaler'], 'v0')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I talked about this in the kapitan slack channel. The idea is that you want to be able to interpolate class names using merged parameters. Imagine having default class versions for multiple targets. That's what `reclass/tests/data/05/classes/versions/default_versions.yml` file sets. Then if each target wants to override that, it can provide it's own parameters to override the default. Then when you call a class defining multiple classes for targets `reclass/tests/data/05/classes/components/common.yml` the parameters are already merged and therefore there is only one option in the interpolation of class names.