### PR TITLE
Avoid modifying context.parameters during class resolution

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,8 @@ verify_ssl = true
 name = "pypi"
 
 [dev-packages]
+mock = "*"
+ddt = "*"
 
 [packages]
 pyparsing = "*"

--- a/reclass/core.py
+++ b/reclass/core.py
@@ -125,9 +125,11 @@ class Core(object):
                     klass = str(self._parser.parse(klass, self._settings).render(merge_base.parameters.as_dict(), {}))
                 except ResolveError as e:
                     try:
+                        # make copy of context.parameters to avoid polluting the original with this interpolation
+                        params = copy.deepcopy(context.parameters)
                         # interpolate parameters before using them in the klass name. Used for overrides
-                        context.parameters.initialise_interpolation()
-                        klass = str(self._parser.parse(klass, self._settings).render(context.parameters.as_dict(), {}))
+                        params.initialise_interpolation()
+                        klass = str(self._parser.parse(klass, self._settings).render(params.as_dict(), {}))
                     except ResolveError as e:
                         raise ClassNameResolveError(klass, nodename, entity.uri)
 

--- a/reclass/datatypes/parameters.py
+++ b/reclass/datatypes/parameters.py
@@ -184,11 +184,7 @@ class Parameters(object):
             else:
                 value = self._merge_recurse(cur.get(key), value)
             cur[key] = value
-        
-        try:
-            cur.uri = new.uri
-        except AttributeError:
-            cur['uri'] = new.uri
+        cur.uri = new.uri
 
         return cur
 


### PR DESCRIPTION
The initial implementation to allow parameter interpolation to be used in class names (#2) resulted in `uri` fields peppered all over the resulting parameters object, due to the [try-catch] when setting `cur.uri` introduced in `Parameters._merge_dict`, which would put a key`uri` into the merged parameters dict, if the passed in `cur` is a plain dict instead of a `ParameterDict`.

As far as I can figure out, this happens when multiple classes are defined using parameters. I suspect that in this case, the `context.parameters` object is initialised for interpolation multiple times which leads to odd behaviour and results in a call to `Parameters._merge_dict` where cur is a plain dict instead of a `ParameterDict`.

By creating a deepcopy of `context.parameters` when interpolating the context parameters during class resolution, we completely avoid the situation that we try to (re)initialise interpolation on `context.parameters`, and the original copy of `context.parameters` remains untouched during class resolution.

With this change, we can remove the try-catch when setting `cur.uri` in `Parameters._merge_dict`, as we now always have properly only-once initialised Parameters objects for interpolation.

[try-catch]: https://github.com/kapicorp/reclass/blob/2585bfc620ddd8c2cd7d159c4eb6d117a526a819/reclass/datatypes/parameters.py#L188-L191