### PR TITLE
Adjust _recurse_entity to process removal in the applications array depth-first

### DIFF
--- a/reclass/core.py
+++ b/reclass/core.py
@@ -103,7 +103,7 @@ class Core(object):
         p = Parameters(self._input_data, self._settings)
         return Entity(self._settings, parameters=p, name='input data')
 
-    def _recurse_entity(self, entity, merge_base=None, context=None, seen=None, nodename=None, environment=None):
+    def _recurse_entity(self, entity, merge_base=None, seen=None, nodename=None, environment=None):
         if seen is None:
             seen = {}
 
@@ -112,9 +112,6 @@ class Core(object):
 
         if merge_base is None:
             merge_base = Entity(self._settings, name='empty (@{0})'.format(nodename))
-
-        if context is None:
-            context = Entity(self._settings, name='empty (@{0})'.format(nodename))
 
         for klass in entity.classes.as_list():
             # class name contain reference
@@ -151,8 +148,8 @@ class Core(object):
 
                 # on every iteration, we pass what we have so far into the
                 # recursive descent …
-                descent = self._recurse_entity(class_entity, merge_base=merge_base, context=context,
-                                               seen=seen, nodename=nodename, environment=environment)
+                descent = self._recurse_entity(class_entity, merge_base=merge_base, seen=seen,
+                                               nodename=nodename, environment=environment)
                 # … therefore, we don't need to merge the result of the
                 # recursive descent as the result is a reference to the same
                 # merge_base object we passed to the call originally, with the
@@ -227,7 +224,7 @@ class Core(object):
         seen = {}
         merge_base = self._recurse_entity(base_entity, seen=seen, nodename=nodename,
                                           environment=node_entity.environment)
-        return self._recurse_entity(node_entity, merge_base=merge_base, context=merge_base, seen=seen,
+        return self._recurse_entity(node_entity, merge_base=merge_base, seen=seen,
                                     nodename=nodename, environment=node_entity.environment)
 
     def _nodeinfo(self, nodename, inventory):

--- a/reclass/tests/data/06/classes/applications/shared.yml
+++ b/reclass/tests/data/06/classes/applications/shared.yml
@@ -1,0 +1,5 @@
+applications:
+  - app1
+  - app2
+  - app3
+  - app4

--- a/reclass/tests/data/06/classes/environments/envA.yml
+++ b/reclass/tests/data/06/classes/environments/envA.yml
@@ -1,0 +1,4 @@
+applications:
+  - ~app4 # envA replaces app4 with app5 (think mariadb vs mysql)
+  - app5
+  - appA

--- a/reclass/tests/data/06/classes/environments/envB.yml
+++ b/reclass/tests/data/06/classes/environments/envB.yml
@@ -1,0 +1,2 @@
+applications:
+  - appB # envB just adds their custom application B

--- a/reclass/tests/data/06/nodes/A_node.yml
+++ b/reclass/tests/data/06/nodes/A_node.yml
@@ -1,0 +1,11 @@
+classes:
+  - applications.shared
+  - environments.envA
+
+parameters:
+  expected_apps:
+    - app1
+    - app2
+    - app3
+    - app5
+    - appA

--- a/reclass/tests/data/06/nodes/B_node.yml
+++ b/reclass/tests/data/06/nodes/B_node.yml
@@ -1,0 +1,11 @@
+classes:
+  - applications.shared
+  - environments.envB
+
+parameters:
+  expected_apps:
+    - app1
+    - app2
+    - app3
+    - app4
+    - appB

--- a/reclass/tests/test_core.py
+++ b/reclass/tests/test_core.py
@@ -114,6 +114,14 @@ class TestCore(unittest.TestCase):
         self.assertEqual(prd['parameters']['loaded_from']['core_dns'], 'v0')
         self.assertEqual(prd['parameters']['loaded_from']['cluster_autoscaler'], 'v0')
 
+    def test_application_removal(self):
+        reclass = self._core('06')
+
+        A_node = reclass.nodeinfo('A_node')
+        B_node = reclass.nodeinfo('B_node')
+
+        self.assertEqual(A_node['applications'], A_node['parameters']['expected_apps'])
+        self.assertEqual(B_node['applications'], B_node['parameters']['expected_apps'])
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Context

In [Commodore](https://github.com/projectsyn/commodore) (our tooling around Kapitan) we're looking for a way to allow us to remove dependencies that were introduced at a previous point in the hierarchy (cf. https://github.com/projectsyn/commodore/issues/71). Commodore makes heavy use of the depth-first manner in which ancestors are traversed to implement a configuration hierarchy that supports multi-tenancy. We have been looking at the `applications` array as an option to allow classes to remove dependencies which were added by classes that were listed before them in the `classes` array.

A simple test (https://github.com/kapicorp/reclass/commit/df8c55aed60daee5d67a017cb24cbb846dd411f9) shows that currently classes cannot remove entries in the `applications` array which were introduced by classes included before them at the same level.

## Background

With the previous implementation, the `applications` array was handled individually for each ancestor of an entity. This appears to contradict the description of how [data merging] is performed in the reclass documentation. The documentation specifies that

> Next, reclass recursively descends each class, looking at the classes it defines, and so on, until a leaf node is reached, i.e. a class that references no other classes.
>
> Now, the merging starts. At every step, the list of applications and the set of parameters at each level is merged into what has been accumulated so far.

So, classes are traversed depth-first in the order they're given in the `classes` array.

The implementation correctly merges parameters and addititons to the applications array depth-first in the order the classes are given.

However, the current implementation doesn't process removal for the `applications` array in a truly depth-first manner. The cause is that removal of entries in the `applications` array is processed immediately when a "~"-prefixed entry is found. Therefore removal of entries is only possible at different levels of the hierarchy, as the current implementation starts the traversal of each ancestor of a class with the same input data, and merges the result of the traversal into the accumulated result after the traversal completes.

As noted above, this post-traversal merging works fine for purely additive operations, but doesn't correctly handle subtractive
operations, as those are processed immediately when they're encountered, and are not visible at the time the merging actually takes place.

## Change

This PR changes `_recurse_entity` to instead start each traversal using the already accumulated data as the base for the traversal. With this change, if a "~"-prefixed entry is found in an ancestor, the recursion has a fully-updated base on which it can process the removal. This allows a class to remove entries in `applications` which were added by classes that were listed before it in the `classes` array.

By changing how we update `merge_base` during recursive calls to `_recurse_entity`, we also need to refactor the code implemented to support references in class names. With the new approach to updating `merge_base`, we can create a deep copy of `merge_base.parameters` which we can use to resolve and references using the already accumulated set of parameters.

With the change to how we implement the data merging during recursion, we do not use the `context` parameter at all anymore, and therefore completely remove it.

[data merging]: https://reclass.pantsfullofunix.net/operations.html#data-merging