### PR TITLE
Improved target names variables

### DIFF
--- a/reclass/core.py
+++ b/reclass/core.py
@@ -16,7 +16,7 @@ import time
 import re
 import fnmatch
 import shlex
-import string
+import os
 import sys
 import yaml
 
@@ -169,7 +169,9 @@ class Core(object):
                 '_reclass_': {
                     'name': {
                         'full': nodename,
-                        'short': nodename.split('.')[0]
+                        'short': nodename.split('.').pop(),
+                        'path': os.path.join(*nodename.split('.')),
+                        'parts': nodename.split('.')
                     },
                 'environment': environment
                 }


### PR DESCRIPTION
When using the `compose_node_name: true`, for example for the following
```
gcp\
  project1.yml
  project2.yml
```
then the inventory will render as such:

```
parameters:
  _reclass_:
    environment: base
    name:
      full: gcp.project1
      short: gcp
```
while the expected behaviour for Kapitan would be

```
parameters:
  _reclass_:
    environment: base
    name:
      full: gcp.project1
      short: project1
```

Additionally, this PR also adds support for exposing the list of parts composing the path

```
parameters:
  _reclass_:
    environment: base
    name:
      full: gcp.project1
      parts:
        - gcp
        - project1
      path: gcp/project1
      short: project1
```
