### PR TITLE
feat(parser): support ref-tags with default values 

### DIFF
--- a/README-extensions.rst
+++ b/README-extensions.rst
@@ -203,6 +203,46 @@ The ``${beta:${alpha:two}}`` construct first resolves the ``${alpha:two}`` refer
 the reference ``${beta:a}`` to the value 99.
 
 
+Default values
+-----------------
+
+References can now have a default value, if the reference couldn't get resolved, for example:
+
+.. code-block:: yaml
+
+  # nodes/node1.yml
+  parameters:
+    myvalue: ${not:existing:ref||default}
+
+``reclass.py --nodeinfo node1`` then gives:
+
+.. code-block:: yaml
+
+  parameters:
+    myvalue: default
+
+The ``${not:existing:ref||default}`` construct searches for a value at ``not:existing:ref``, and then because it can't find any, it will take the default value.
+
+This works for nested references as well:
+
+.. code-block:: yaml
+
+  # nodes/node1.yml
+  parameters:
+    default: 123
+    a: ${not:existing:ref||${default}}
+    b: ${not:existing:ref||${not:existing:default||fallback}}
+
+``reclass.py --nodeinfo node1`` then gives:
+
+.. code-block:: yaml
+
+  parameters:
+    default: 123
+    a: 123
+    b: fallback
+
+
 Ignore overwritten missing references
 -------------------------------------
 

--- a/reclass/datatypes/tests/test_parameters.py
+++ b/reclass/datatypes/tests/test_parameters.py
@@ -414,6 +414,20 @@ class TestParametersNoMock(unittest.TestCase):
         p.interpolate()
         self.assertEqual(p.as_dict(), r)
 
+    def test_nested_references_default_exists(self):
+        values = {"a": "value", "b": "${not:existing||${a}}"}
+        reference = {"a": "value", "b": "value"}
+        parameters = Parameters(values, SETTINGS, '')
+        parameters.interpolate()
+        self.assertEqual(parameters.as_dict(), reference)
+
+    def test_nested_references_default_exists(self):
+        values = {"a": "value", "b": "${not:existing||${again||fallback}}"}
+        reference = {"a": "value", "b": "fallback"}
+        parameters = Parameters(values, SETTINGS, '')
+        parameters.interpolate()
+        self.assertEqual(parameters.as_dict(), reference)
+
     def test_stray_occurrence_overwrites_during_interpolation(self):
         p1 = Parameters({'r' : 1, 'b': '${r}'}, SETTINGS, '')
         p2 = Parameters({'b' : 2}, SETTINGS, '')

--- a/reclass/utils/dictpath.py
+++ b/reclass/utils/dictpath.py
@@ -67,6 +67,8 @@ class DictPath(object):
         elif isinstance(contents, list):
             self._parts = contents
         elif isinstance(contents, six.string_types):
+            # parse the default value from contents, strip default section (|...) from parts            
+            contents, self.default = self._split_default(contents)
             self._parts = self._split_string(contents)
         elif isinstance(contents, tuple):
             self._parts = list(contents)
@@ -114,6 +116,18 @@ class DictPath(object):
 
     def _split_string(self, string):
         return re.split(r'(?<!\\)' + re.escape(self._delim), string)
+
+    def _split_default(self, string):
+        """
+        splits reference tag 'my:tag|default-value' into two parts
+        """
+        parts = string.split("|")
+        if not parts: 
+            return None # no contents at all
+        elif len(parts) == 1:
+            return parts[0], None # no default
+        else:
+            return parts[:-1][0], parts[-1] # contain '|' in contents and use just the last '|'
 
     def key_parts(self):
         return self._parts[:-1]

--- a/reclass/utils/dictpath.py
+++ b/reclass/utils/dictpath.py
@@ -67,7 +67,7 @@ class DictPath(object):
         elif isinstance(contents, list):
             self._parts = contents
         elif isinstance(contents, six.string_types):
-            # parse the default value from contents, strip default section (|...) from parts            
+            # parse the default value from contents, strip default section (||...) from parts            
             contents, self.default = self._split_default(contents)
             self._parts = self._split_string(contents)
         elif isinstance(contents, tuple):
@@ -119,15 +119,15 @@ class DictPath(object):
 
     def _split_default(self, string):
         """
-        splits reference tag 'my:tag|default-value' into two parts
+        splits reference tag 'my:tag||default-value' into two parts
         """
-        parts = string.split("|")
+        parts = string.split("||")
         if not parts: 
             return None # no contents at all
         elif len(parts) == 1:
             return parts[0], None # no default
         else:
-            return parts[:-1][0], parts[-1] # contain '|' in contents and use just the last '|'
+            return parts[:-1][0], parts[-1] # contain '||' in contents and use just the last '||'
 
     def key_parts(self):
         return self._parts[:-1]

--- a/reclass/values/refitem.py
+++ b/reclass/values/refitem.py
@@ -29,6 +29,8 @@ class RefItem(item.ItemWithReferences):
         try:
             return path.get_value(context)
         except (KeyError, TypeError) as e:
+            if path.default:
+                return path.default
             raise ResolveError(ref)
 
     def render(self, context, inventory):

--- a/reclass/values/refitem.py
+++ b/reclass/values/refitem.py
@@ -29,8 +29,10 @@ class RefItem(item.ItemWithReferences):
         try:
             return path.get_value(context)
         except (KeyError, TypeError) as e:
-            if path.default:
-                return path.default
+            if refpath.default is not None:
+                if refpath.default == '':
+                    refpath.default = None
+                return refpath.default
             raise ResolveError(ref)
 
     def render(self, context, inventory):

--- a/reclass/values/tests/test_refitem.py
+++ b/reclass/values/tests/test_refitem.py
@@ -49,6 +49,11 @@ class TestRefItem(unittest.TestCase):
         result = reference._resolve('non:existing||default', {'foo':'bar'})
         self.assertEquals(result, 'default')
 
+    def test_default_exists_resolve_ok(self):
+        reference = RefItem('', Settings({'delimiter': ':'}))
+        result = reference._resolve('foo||default', {'foo':'bar'})
+        self.assertEquals(result, 'bar')
+
     def test__resolve_fails(self):
         refitem = RefItem('', Settings({'delimiter': ':'}))
         context = {'foo':{'bar': 1}}

--- a/reclass/values/tests/test_refitem.py
+++ b/reclass/values/tests/test_refitem.py
@@ -44,6 +44,11 @@ class TestRefItem(unittest.TestCase):
 
         self.assertEquals(result, 1)
 
+    def test_default_resolve_ok(self):
+        reference = RefItem('', Settings({'delimiter': ':'}))
+        result = reference._resolve('non:existing||default', {'foo':'bar'})
+        self.assertEquals(result, 'default')
+
     def test__resolve_fails(self):
         refitem = RefItem('', Settings({'delimiter': ':'}))
         context = {'foo':{'bar': 1}}


### PR DESCRIPTION
## Proposed Changes
* Added support for specifying default values for non existing keys / dictionary-paths
* Extended functionality to support a reference-tag as default value, e.g. `${spec:value||${default:value||another-default}}`
* Use `||` as delimiter, because it fits well in the kapitan ecosystem

### Examples
```yaml 
parameters:
  existing:
    key: myvalue

  foo: ${non:existing:key||bar} # --> bar (default value)
  mykey: ${existing:key||bar} # --> myvalue (value exists)
```

```yaml 
parameters:
  defaults:  
    default1: myDefault

  spec:
    spec1: ${not:existing||${defaults:default1}} # --> myDefault (tag in default-value exists)
    spec2: ${not:existing||${defaults:notfound||fallback}} # --> fallback (tag in default-value not exists, default gets taken) 
```

## Breaking changes
* You should not have the `||` - delimiter in your yaml-keys anymore!

## To Do
* [X] Add tests
* [X] Add documentation (also in kapitan docs) 
  @ademariag Where should this be done? 

--- 
### Contributed by  [<img src="https://www.nexenio.com/wp-content/uploads/2021/10/001-nexenio-logo-white-rgb@2x-e1636042495927.png" height="15em" />](https://www.nexenio.com)
